### PR TITLE
Add configurable menus

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -239,7 +239,7 @@ KeystoneGenerator.prototype.project = function project() {
 
 KeystoneGenerator.prototype.models = function models() {
 
-	var modelFiles = ['users'],
+	var modelFiles = ['users', 'menuItems'],
 		modelIndex = '';
 
 	if (this.includeBlog) {
@@ -327,9 +327,10 @@ KeystoneGenerator.prototype.templates = function templates() {
 
 };
 
-KeystoneGenerator.prototype.udpates = function routes() {
+KeystoneGenerator.prototype.updates = function routes() {
 
-	this.directory('updates');
+	this.copy('updates/0.0.1-admins.js');
+	this.template('updates/_0.0.2-menuitems.js', 'updates/0.0.2-menuitems.js');
 
 };
 

--- a/app/templates/_keystone.js
+++ b/app/templates/_keystone.js
@@ -93,7 +93,8 @@ keystone.set('nav', {
 	<% if (includeBlog) { %>'posts': ['posts', 'post-categories'],
 	<% } if (includeGallery) { %>'galleries': 'galleries',
 	<% } if (includeEnquiries) { %>'enquiries': 'enquiries',
-	<% } %>'users': 'users'
+	<% } %>'menu' : 'menu-items',
+	'users': 'users'
 });
 <% if (includeGuideComments) { %>
 // Start Keystone to connect to your database and initialise the web server

--- a/app/templates/models/menuItems.js
+++ b/app/templates/models/menuItems.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var keystone = require( 'keystone' ),
+	Types = keystone.Field.Types;
+
+var MenuItem = new keystone.List( 'MenuItem', {
+	map     : { name : 'label' },
+	autokey : {
+		from   : 'label',
+		path   : 'key',
+		unique : true
+	}
+} );
+
+MenuItem.add( {
+	label   : { type : String, required : true },
+	href    : { type : Types.Url, default : '/', required : true },
+	weight  : { type : Types.Number, default : 0 },
+	enabled : { type : Types.Boolean, default : true }
+} );
+
+MenuItem.defaultColumns = 'label, href, weight, enabled';
+MenuItem.register();

--- a/app/templates/routes/_middleware.js
+++ b/app/templates/routes/_middleware.js
@@ -24,18 +24,11 @@
 exports.initLocals = function(req, res, next) {
 	
 	var locals = res.locals;
-	
-	locals.navLinks = [
-		{ label: 'Home',		key: 'home',		href: '/' }<% if (includeBlog) { %>,
-		{ label: 'Blog',		key: 'blog',		href: '/blog' }<% } %><% if (includeGallery) { %>,
-		{ label: 'Gallery',		key: 'gallery',		href: '/gallery' }<% } %><% if (includeEnquiries) { %>,
-		{ label: 'Contact',		key: 'contact',		href: '/contact' }<% } %>
-	];
-	
-	locals.user = req.user;
-	
-	next();
-	
+	keystone.list( 'MenuItem' ).model.find().where( 'enabled', true ).sort( 'weight' ).exec(function( err, results){
+		locals.navLinks = results;
+		locals.user = req.user;
+		next();
+	});	
 };
 
 

--- a/app/templates/updates/_0.0.2-menuitems.js
+++ b/app/templates/updates/_0.0.2-menuitems.js
@@ -1,0 +1,30 @@
+'use strict';
+var keystone = require( 'keystone' );
+var async = require( 'async' );
+var MenuItem = keystone.list( 'MenuItem' );
+
+var menuitems = [
+	{ label: 'Home',		key: 'home',		weight : 0,		href: '/' }<% if (includeBlog) { %>,
+	{ label: 'Blog',		key: 'blog',		weight : 10,	href: '/blog' }<% } %><% if (includeGallery) { %>,
+	{ label: 'Gallery',		key: 'gallery',		weight : 20,	href: '/gallery' }<% } %><% if (includeEnquiries) { %>,
+	{ label: 'Contact',		key: 'contact',		weight : 30,	href: '/contact' }<% } %>
+];
+
+function createMenuItem(menuitem, done){
+
+	var newMenuItem = new MenuItem.model( menuitem );
+	newMenuItem.save( function( err ){
+		 if( err ){
+			 console.error( "Error adding menu item " + newMenuItem.label + " to the database:" );
+			 console.error( err );
+		 }else{
+			 console.log( "Added menu item " + newMenuItem.label + " to the database." );
+		 }
+		 done();
+	 } );
+	
+}
+
+exports = module.exports = function( done ){
+	async.forEach( menuitems, createMenuItem, done );
+};


### PR DESCRIPTION
Hi @JedWatson,

I needed configurable menus for my current keystone project and thought it might be useful to provide them out-of-the-box. It's pretty basic, it simply shifts the hard-coded navigation items to a model and serves them in the admin UI, obviously the views etc. still need to be created. The main advantage is that content admins are able to add links to dynamically created content.

It does make the most sense when you got some kind of "Page" model. If you're interested I can add a PR for that as well.