### PR TITLE
Lowered the required "yo" version. #fixes 34

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mocha": "~1.20.1"
   },
   "peerDependencies": {
-    "yo": "~1.2.0"
+    "yo": ">=1.0.0"
   },
   "engines": {
     "node": ">=0.10.0",


### PR DESCRIPTION
generator-keystone normally working with v1.0.0 of yo
