### PR TITLE
#42 css style fix to use bootstraps glyphicon components instead of enty...

### DIFF
--- a/app/templates/templates/default-hbs/views/partials/pagination.hbs
+++ b/app/templates/templates/default-hbs/views/partials/pagination.hbs
@@ -1,13 +1,13 @@
 <ul class="pagination">
 	<li {{#unless data.posts.previous}}class="disabled"{{/unless}}>
 		<a href="{{paginationPreviousUrl data.posts.previous}}">
-			<span class="entypo entypo-chevron-thin-left"></span>
+			<span class="glyphicon glyphicon-chevron-left"></span>
 		</a>
 	</li>
 	{{{paginationNavigation data.posts.pages data.posts.currentPage data.posts.totalPages}}}
 	<li {{#unless data.posts.next}}class="disabled"{{/unless}}>
 		<a href="{{paginationNextUrl data.posts.next data.posts.totalPages}}">
-			<span class="entypo entypo-chevron-thin-right"></span>
+			<span class="glyphicon glyphicon-chevron-right"></span>
 		</a>
 	</li>
 </ul>

--- a/app/templates/templates/default-jade/views/blog.jade
+++ b/app/templates/templates/default-jade/views/blog.jade
@@ -50,16 +50,16 @@ block content
 					if data.posts.totalPages > 1
 						ul.pagination
 							if data.posts.previous
-								li: a(href='?page=' + data.posts.previous): span.entypo.entypo-chevron-thin-left
+								li: a(href='?page=' + data.posts.previous): span.glyphicon.glyphicon-chevron-left
 							else
-								li.disabled: a(href='?page=' + 1): span.entypo.entypo-chevron-thin-left
+								li.disabled: a(href='?page=' + 1): span.glyphicon.glyphicon-chevron-left
 							each p, i in data.posts.pages
 								li(class=data.posts.currentPage == p ? 'active' : null)
 									a(href='?page=' + (p == '...' ? (i ? data.posts.totalPages : 1) : p ))= p
 							if data.posts.next
-								li: a(href='?page=' + data.posts.next): span.entypo.entypo-chevron-thin-right
+								li: a(href='?page=' + data.posts.next): span.glyphicon.glyphicon-chevron-right
 							else
-								li.disabled: a(href='?page=' + data.posts.totalPages): span.entypo.entypo-chevron-thin-right
+								li.disabled: a(href='?page=' + data.posts.totalPages): span.entypo.glyphicon.glyphicon-chevron-right
 				else
 					if data.category
 						h3.text-muted There are no posts in the category #{data.category.name}.

--- a/app/templates/templates/default-swig/views/blog.swig
+++ b/app/templates/templates/default-swig/views/blog.swig
@@ -68,13 +68,13 @@
     							{% if data.posts.previous %}
     								<li>
                                         <a href="?page={{ data.posts.previous }}">
-                                            <span class="entypo entypo-chevron-thin-left"></span>
+                                            <span class="glyphicon glyphicon-chevron-left"></span>
                                         </a>
                                     </li>
     							{% else %}
     								<li class="disabled">
                                         <a href="?page=1">
-                                            <span class="entypo entypo-chevron-thin-left"></span>
+                                            <span class="glyphicon glyphicon-chevron-left"></span>
                                         </a>
                                     </li>
         							{% for p in data.posts.pages %}
@@ -87,13 +87,13 @@
     							{% if data.posts.next %}
     								<li>
                                         <a href="?page={{ data.posts.next }}">
-                                            <span class="entypo entypo-chevron-thin-right"></span>
+                                            <span class="glyphicon glyphicon-chevron-right"></span>
                                         </a>
                                     </li>
     							{% else %}
     								<li class="disabled">
                                         <a href="?page={{ data.posts.totalPages }}">
-                                            <span class="entypo entypo-chevron-thin-right"></span>
+                                            <span class="glyphicon glyphicon-chevron-right"></span>
                                         </a>
                                     </li>
                                 {% endif %}


### PR DESCRIPTION
Add the correct css style selectors using `glyphicon` from the [component](http://getbootstrap.com/components/) section.

**This closes issue** #42

Attached Screenshot of Boostrap Buttons
![screen shot 2014-07-26 at 3 24 50 pm](https://cloud.githubusercontent.com/assets/89339/3712075/e7c4f7d8-14fb-11e4-97ba-1b7afcc4db80.png)
