### PR TITLE
If no hero image is set an error is thrown when viewing the gallery (handlebars).

### DIFF
--- a/app/templates/templates/default-hbs/views/helpers/index.js
+++ b/app/templates/templates/default-hbs/views/helpers/index.js
@@ -201,6 +201,11 @@ module.exports = function() {
 		// safe guard to ensure context is never null
 		context = context === null ? undefined : context;
 		
+		// If no image is set don't try to process it 
+		// (e.g. no hero image)
+		if (context === undefined || !context.url)
+			return null;
+		
 		var publicId = context.public_id,
 			width = ((options.width) ? options.width : '300'),
 			height = ((options.height) ? options.height : '300');


### PR DESCRIPTION
If you create a gallery but don't add a hero image an error is thrown in the cloudinaryURL helper.

It assumes that the context will have a url attribute but if there is no hero image the context is an empty object.

This fix just checks that a url attribute exists and if not returns null.
I feel this isn't the best solution but I don't know enough about helpers to fix it properly! 
