### PR TITLE
added case for undefined data so pagination returns empty

### DIFF
--- a/app/templates/templates/default-hbs/views/helpers/index.js
+++ b/app/templates/templates/default-hbs/views/helpers/index.js
@@ -247,12 +247,17 @@ module.exports = function() {
 	* expecting the data.posts context or an object literal that has `previous` and `next` properties
 	* ifBlock helpers in hbs - http://stackoverflow.com/questions/8554517/handlerbars-js-using-an-helper-function-in-a-if-statement
 	* */
- 	_helpers.ifHasPagination = function(postContext, options){
+	_helpers.ifHasPagination = function(postContext, options){
+		// if implementor fails to scope properly or has an empty data set
+		// better to display else block than throw an exception for undefined
+		if(_.isUndefined(postContext)){
+			return options.inverse(this);
+		}
 		if(postContext.next || postContext.previous){
 			return options.fn(this);
 		}
- 		return options.inverse(this);
-	}
+		return options.inverse(this);
+	};
 	
 	_helpers.paginationNavigation = function(pages, currentPage, totalPages, options){
 		var html = '';


### PR DESCRIPTION
fixes an issue with undefined contexts from an empty result set being passed into the helper which throws an exception and breaks the renderer.  Not part of the keystoneJS demo and is only being used by custom themes that want to hide pagination altogether if none exists.
