### PR TITLE
Handlebars Blog Categories fix

### DIFF
--- a/app/templates/templates/default-hbs/views/helpers/index.js
+++ b/app/templates/templates/default-hbs/views/helpers/index.js
@@ -105,7 +105,7 @@ module.exports = function() {
 			if (autolink) {
 				return _.map(tags, function(tag) {
 					return linkTemplate({
-						url: ('blog/' + tag.key),
+						url: ('/blog/' + tag.key),
 						text: _.escape(tag.name)
 					});
 				}).join(separator);


### PR DESCRIPTION
There was a missing '/' on the helpers file for handlebar templating. The fix allows the blog to correctly go to the links once your in a blog post.
