### PR TITLE
Fix User model template so relationship definition to Post is properly referenced 

### DIFF
--- a/app/templates/models/_User.js
+++ b/app/templates/models/_User.js
@@ -26,7 +26,7 @@ var <%= userModel %> = new keystone.List('<%= userModel %>');
  * Relationships
  */
 
-<%= userModel %>.relationship({ ref: 'Post', path: 'author' });
+<%= userModel %>.relationship({ ref: 'Post', path: 'posts', refPath: 'author' });
 
 <% } %>
 /**


### PR DESCRIPTION
I noticed the User model created by the Yeoman Generator wasn't properly letting the admin user see a list of the Posts by each Author; this change matches the doc on keystonejs.com and shows a list of Posts as the admin user would expect.