### PR TITLE
Update gulp semver in _package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -31,7 +31,7 @@
     "open": "0.0.5"
   },<% } else if (taskRunner === 'gulp') { %>
   "devDependencies": {
-    "gulp": "~3.6.4",
+    "gulp": "~3.7.0",
     "gulp-jshint": "~1.9.0",
     "jshint-stylish": "~0.1.3",
     "gulp-watch": "~0.6.5"


### PR DESCRIPTION
Update gulp to at least ~3.7.0 to prevent generator from breaking when choosing gulp as your task runner. Looks like version > 3.6.2 was never published or removed from the registry?