### PR TITLE
Fix "Open Admin UI" link

### DIFF
--- a/app/templates/templates/default-jade/views/index.jade
+++ b/app/templates/templates/default-jade/views/index.jade
@@ -12,7 +12,7 @@ block content
 		hr
 		if user && user.canAccessKeystone
 			p
-				a(href='/keystone/signin').btn.btn-lg.btn-primary Open the Admin UI
+				a(href='/keystone').btn.btn-lg.btn-primary Open the Admin UI
 		else
 			p We have created a default Admin user for you with the email <strong><%= adminLogin %></strong> and the password <strong><%= adminPassword %></strong>.
 			p

--- a/app/templates/templates/default-nunjucks/views/index.html
+++ b/app/templates/templates/default-nunjucks/views/index.html
@@ -15,7 +15,7 @@
 			<hr>
 			{% if user and user.canAccessKeystone %}
 				<p>
-					<a href="/keystone/signin" class="btn btn-lg btn-primary">Open the Admin UI</a>
+					<a href="/keystone" class="btn btn-lg btn-primary">Open the Admin UI</a>
 				</p>
 			{% else %}
 				<p>We have created a default Admin user for you with the email <strong><%= adminLogin %></strong> and the password <strong><%= adminPassword %></strong>.</p>

--- a/app/templates/templates/default-swig/views/index.swig
+++ b/app/templates/templates/default-swig/views/index.swig
@@ -15,7 +15,7 @@
 			<hr>
 			{% if user and user.canAccessKeystone %}
 				<p>
-					<a href="/keystone/signin" class="btn btn-lg btn-primary">Open the Admin UI</a>
+					<a href="/keystone" class="btn btn-lg btn-primary">Open the Admin UI</a>
 				</p>
 			{% else %}
 				<p>We have created a default Admin user for you with the email <strong><%= adminLogin %></strong> and the password <strong><%= adminPassword %></strong>.</p>


### PR DESCRIPTION
Before it pointed to ```/keystone/signin```, I took out the ```signin```.