### PR TITLE
glyphicons are in /fonts folder rather in /fonts/bootstrap/

### DIFF
--- a/app/templates/public/styles-sass/bootstrap/bootstrap/_variables.scss
+++ b/app/templates/public/styles-sass/bootstrap/bootstrap/_variables.scss
@@ -80,7 +80,7 @@ $headings-color:          inherit !default;
 
 // [converter] If $bootstrap-sass-asset-helper if used, provide path relative to the assets load path.
 // [converter] This is because some asset helpers, such as Sprockets, do not work with file-relative paths.
-$icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/bootstrap/") !default;
+$icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/") !default;
 
 //** File name for all font files.
 $icon-font-name:          "glyphicons-halflings-regular" !default;


### PR DESCRIPTION
glyphicons fonts are now in /public/fonts/ while the style was generating the path for /public/fonts/bootstrap/