### PR TITLE
Amending the path name to categories as per the relationship path.

### DIFF
--- a/app/templates/routes/views/blog.js
+++ b/app/templates/routes/views/blog.js
@@ -30,7 +30,7 @@ exports = module.exports = function(req, res) {
 			// Load the counts for each category
 			async.each(locals.data.categories, function(category, next) {
 				
-				keystone.list('Post').model.count().where('category').in([category.id]).exec(function(err, count) {
+				keystone.list('Post').model.count().where('categories').in([category.id]).exec(function(err, count) {
 					category.postCount = count;
 					next(err);
 				});


### PR DESCRIPTION
Although the query is made to get counts of posts for each category, the count returned was always zero - so therefore category.postCount was always zero and couldn't be reliably used in the blog view. The reason for that was use of the incorrect path in the query in the Post collection - the relationship path with Post in the PostCategory model is 'categories'.