### PR TITLE
Look for the appropriate `hbs` file if handlebars is chosen as the view engine

### DIFF
--- a/app/templates/models/Enquiry.js
+++ b/app/templates/models/Enquiry.js
@@ -47,7 +47,13 @@ Enquiry.schema.methods.sendNotificationEmail = function(callback) {
 		
 		if (err) return callback(err);
 		
-		new keystone.Email('enquiry-notification').send({
+		new keystone.Email({
+			<% if (viewEngine === 'hbs') { %>
+				templateExt: 'hbs',
+				templateEngine: require('express-handlebars'),
+			<% } %>
+		  templateName: 'enquiry-notification'
+		}).send({
 			to: admins,
 			from: {
 				name: '<%= projectName %>',


### PR DESCRIPTION
Mandrill email notifications do not work if handlebars is selected as the view engine.

This doesn't seem to affect any other view engine considering there are no other issues related besides this one: 

https://github.com/keystonejs/keystone/issues/1441