### PR TITLE
Only print email locals guide comment when email is enabled.

### DIFF
--- a/app/templates/_keystone.js
+++ b/app/templates/_keystone.js
@@ -70,10 +70,11 @@ keystone.set('locals', {
 // Load your project's Routes
 <% } %>
 keystone.set('routes', require('./routes'));
+<% if (includeEmail) { %>
 <% if (includeGuideComments) { %>
 // Setup common locals for your emails. The following are required by Keystone's
 // default email templates, you may remove them if you're using your own.
-<% } %><% if (includeEmail) { %>
+<% } %>
 keystone.set('email locals', {
 	logo_src: '/images/logo-email.gif',
 	logo_width: 194,


### PR DESCRIPTION
Just a little fix so the comment won't be out of place when guide comments are enabled but email isn't.