### PR TITLE
Disable es3 jshint rule

### DIFF
--- a/app/templates/_jshintrc
+++ b/app/templates/_jshintrc
@@ -3,7 +3,7 @@
   "camelcase": true,
   "curly": false,  /* custom */
   "eqeqeq": true,
-  "es3": true,
+  "es3": false,
   "forin": true,
   "freeze": true,
   "immed": true,


### PR DESCRIPTION
fixes https://github.com/keystonejs/generator-keystone/issues/123
Out of the box linting fails due to usage of es3 reserved word `import`
by keystone api.