### PR TITLE
Initial React View Engine

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -85,8 +85,8 @@ KeystoneGenerator.prototype.prompts = function prompts () {
 				default: 'My Site',
 			}, {
 				name: 'viewEngine',
-				message: 'Would you like to use Jade, Swig, Nunjucks, Twig or Handlebars for templates? ' + (('[jade | swig | nunjucks | twig | hbs]').grey),
-				default: 'jade',
+				message: 'Would you like to use Jade, React, Swig, Nunjucks or Handlebars for templates? ' + (('[jade | react | swig | nunjucks | hbs ]').grey),
+				default: 'jade'
 			}, {
 				name: 'preprocessor',
 				message: 'Which CSS pre-processor would you like? ' + (('[less | sass | stylus]').grey),
@@ -161,6 +161,8 @@ KeystoneGenerator.prototype.prompts = function prompts () {
 			this.viewEngine = 'swig';
 		} else if (_.includes(['nunjucks', 'nun', 'n'], this.viewEngine.toLowerCase().trim())) {
 			this.viewEngine = 'nunjucks';
+		} else if (_.includes(['react', 'reactjs', 'r'], this.viewEngine.toLowerCase().trim())) {
+			this.viewEngine = 'react';
 		} else {
 			this.viewEngine = 'jade';
 		}
@@ -413,6 +415,97 @@ KeystoneGenerator.prototype.templates = function templates () {
 			this.copy('templates/default-hbs/views/contact.hbs', 'templates/views/contact.hbs');
 			if (this.includeEmail) {
 				this.copy('templates/default-hbs/emails/enquiry-notification.hbs', 'templates/emails/enquiry-notification.hbs');
+			}
+		}
+
+	} else if (this.viewEngine === 'react') {
+
+		// Create React Templates Directories
+		/**
+		├── components
+		│   ├── elements
+		│   ├── pages
+		│   └── views
+		├── constants
+		└── mixins
+		*/
+		this.mkdir('templates');
+		this.mkdir('templates/components');
+		this.mkdir('templates/components/elements');
+		this.mkdir('templates/components/pages');
+		this.mkdir('templates/components/views');
+		this.mkdir('templates/constants');
+		this.mkdir('templates/mixins');
+
+		// need a layout.jsx which is shell
+		//this.copy('templates/default-react/components/layout.jsx', 'templates/default-react/components/layout.jsx');
+		this.directory('templates/default-react/components', 'templates/components');
+		// then index.jsx should contain the jumbotron component
+		// fill out remaining apps/sections
+
+		// not app/section specific so copy entire folder contents
+		this.directory('templates/default-react/constants', 'templates/constants');
+		this.directory('templates/default-react/mixins', 'templates/mixins');
+
+		// All App specific components are contained in the `components` folder
+		// create stubs for paths
+		var srcPath = 'templates/default-' + this.viewEngine + '/components/';
+		var destPath = 'templates/components/';
+
+		// copy all the required/shared components
+		// need a layout.jsx which is shell for all pages
+		this.copy(srcPath + 'layouts/layout.jsx', destPath + 'layouts/layout.jsx');
+		// shared components and base layer
+		this.copy(srcPath + 'elements' + '/Jumbotron.jsx', destPath + 'elements' + '/Jumbotron.jsx');
+		this.copy(srcPath + 'elements' + '/NavItem.jsx', destPath + 'elements' + '/NavItem.jsx');
+		this.copy(srcPath + 'elements' + '/BlockLink.jsx', destPath + 'elements' + '/BlockLink.jsx');
+		this.copy(srcPath + 'elements' + '/InlineLink.jsx', destPath + 'elements' + '/InlineLink.jsx');
+		this.copy(srcPath + 'elements' + '/Pagination.jsx', destPath + 'elements' + '/Pagination.jsx');
+		this.copy(srcPath + 'elements' + '/PaginationButton.jsx', destPath + 'elements' + '/PaginationButton.jsx');
+		// FlashMessage could be globally used for contact/gallery?
+		this.copy(srcPath + 'elements' + '/FlashMessages.jsx', destPath + 'elements' + '/FlashMessages.jsx');
+		this.copy(srcPath + 'elements' + '/FlashMessage.jsx', destPath + 'elements' + '/FlashMessage.jsx');
+
+		// copy index for the view layer (required for all views to work)
+		this.copy(srcPath + 'views' + '/index.jsx', destPath + 'views' + '/index.jsx');
+		// home page is required by default
+		this.copy(srcPath + 'pages' + '/home.jsx', destPath + 'pages' + '/home.jsx');
+
+		// handle component copying for each app
+		if (this.includeBlog) {
+			// for blog we need both views [blog,post]
+			// views are where express handsoff the template context/vars to react-engine
+			this.copy(srcPath + 'views' + '/blog.jsx', destPath + 'views' + '/blog.jsx');
+			this.copy(srcPath + 'views' + '/post.jsx', destPath + 'views' + '/post.jsx');
+			// pages is the component container to handle what component-elements are loaded
+			// for blog we use the Posts page, but for a single Post we can mount the element directly
+			// into the views/post.jsx
+			this.copy(srcPath + 'pages' + '/Posts.jsx', destPath + 'pages' + '/Posts.jsx');
+			// copy all the necessary component/elements required for blog/posts
+			this.copy(srcPath + 'elements' + '/AuthorByLine.jsx', destPath + 'elements' + '/AuthorByLine.jsx');
+			this.copy(srcPath + 'elements' + '/CategoryBlockLinkList.jsx', destPath + 'elements' + '/CategoryBlockLinkList.jsx');
+			this.copy(srcPath + 'elements' + '/CategoryInlineLinkList.jsx', destPath + 'elements' + '/CategoryInlineLinkList.jsx');
+			this.copy(srcPath + 'elements' + '/PostExcerpt.jsx', destPath + 'elements' + '/PostExcerpt.jsx');
+			this.copy(srcPath + 'elements' + '/PostFull.jsx', destPath + 'elements' + '/PostFull.jsx');
+		}
+
+		if (this.includeGallery) {
+			// copy only gallery templates (view/pages)
+			// views are where express handsoff the template context/vars to react-engine
+			this.copy(srcPath + 'views' + '/gallery.jsx', destPath + 'views' + '/gallery.jsx');
+			// pages is the component container to handle what component-elements are loaded
+			this.copy(srcPath + 'pages' + '/gallery.jsx', destPath + 'pages' + '/gallery.jsx');
+		}
+
+		if (this.includeEnquiries) {
+			// copy only contact templates (pages)
+			// views are where express handsoff the template context/vars to react-engine
+			this.copy(srcPath + 'views' + '/contact.jsx', destPath + 'views' + '/contact.jsx');
+			// pages is the component container to handle what component-elements are loaded
+			this.copy(srcPath + 'pages' + '/ContactForm.jsx', destPath + 'pages' + '/ContactForm.jsx');
+			if (this.includeEmail) {
+				// TODO Add this into template
+				// need template txt
 			}
 		}
 

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -1,4 +1,22 @@
 <%= projectName %>
 =====================
 
+<% if (viewEngine === 'react') { %>
+# ReactJS Generator POC
+
+The work entailed here is for porting reactjs as a template/view for the keystonejs generator.  This includes the homepage, blog, and contact page.  Gallery is work-in-progress.  All react templates are pre-rendered by express and served to the client's browser.  There is currently not a gulp/grunt build tool that transpiles the reactjs application as a naitive browser application.  Though very little work would be entailed in moving to this method, for now having a simple reactjs server-side rendered application is a good starting place.
+
+## KeystoneJS Base Application Layout
+
+For the most part this reactjs generated application mirrors the Handlebars and Jade generated projects as much as possible.
+
+## Getting Started
+
+Assuming you have setup mongodb and have node installed locally
+
+    npm install .
+    node keystone.js
+
+<% } %>
+
 Powered by [KeystoneJS](http://keystonejs.com).

--- a/app/templates/_keystone.js
+++ b/app/templates/_keystone.js
@@ -3,9 +3,10 @@
 require('dotenv').load();
 
 // Require keystone
-var keystone = require('keystone');<% if (viewEngine == 'hbs') { %>
-var handlebars = require('express-handlebars');<% } else if (viewEngine == 'swig') { %>
-var swig = require('swig');<% } else if (viewEngine == 'nunjucks') { %>
+var keystone = require('keystone')<% if (viewEngine == 'hbs') { %>;
+var handlebars = require('express-handlebars')<% } else if (viewEngine == 'swig') { %>;
+var swig = require('swig')<% } else if (viewEngine == 'react') { %>;
+var react = require('express-react-views')<% } else if (viewEngine == 'nunjucks') { %>;
 var cons = require('consolidate');
 var nunjucks = require('nunjucks');<% } else if (viewEngine == 'twig') { %>
 var Twig = require('twig');<% } %>
@@ -32,9 +33,12 @@ keystone.init({
 	'views': ['templates', 'templates/views'],<% if (viewEngine === 'nunjucks') { %>
 	'view engine': 'html',
 	'custom engine': cons.nunjucks,
-<% } else { %>
-	'view engine': '<%= viewEngine %>',
-<% } %><% if (viewEngine === 'hbs') { %>
+	<% } if (viewEngine === 'react') { %>
+	'views': 'templates/components/views',
+	'view engine': 'jsx',
+	'custom engine': react.createEngine(),
+	<% } %>
+  <% if (viewEngine === 'hbs') { %>
 	'custom engine': handlebars.create({
 		layoutsDir: 'templates/views/layouts',
 		partialsDir: 'templates/views/partials',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -9,11 +9,12 @@
     "moment": "^2.10.6",
     "cloudinary": "^1.2.4",
     "express-handlebars": "^3.0.0",
-    "handlebars": "^4.0.5",<% } else if (viewEngine === 'swig') { %>
+    "handlebars": "^4.0.5",<% } else if (viewEngine === 'react') { %>
+    "express-react-views": "~0.7.1",<% } else if (viewEngine === 'swig') { %>
     "swig": "^1.4.1", <% } else if (viewEngine === 'nunjucks') { %>
     "consolidate": "^0.14.1",
     "nunjucks": "^1.0.5", <% } else if (viewEngine === 'twig') { %>
-	"twig":"^0.8.9",
+	  "twig":"^0.8.9",
 	<% } if (preprocessor === 'sass') { %>
     "node-sass": "^3.3.2",
     "node-sass-middleware": "^0.9.7", <% } else if (preprocessor === 'stylus') { %>

--- a/app/templates/templates/default-react/components/elements/AuthorByline.jsx
+++ b/app/templates/templates/default-react/components/elements/AuthorByline.jsx
@@ -1,0 +1,22 @@
+/**
+ * @file a React Component element that acts as the author by line display
+ */
+
+// Include NPM modules
+var React = require('react');
+
+var AuthorByline = React.createClass({
+	displayName: 'AuthorByline',
+	propTypes: {
+		name: React.PropTypes.string.isRequired  // Need the first name
+	},
+	render: function(){
+		return (
+			<span>
+				by {this.props.name}
+			</span>		
+		);		
+	}
+});
+
+module.exports = AuthorByline;

--- a/app/templates/templates/default-react/components/elements/BlockLink.jsx
+++ b/app/templates/templates/default-react/components/elements/BlockLink.jsx
@@ -1,0 +1,25 @@
+/**
+ * @file a React Component element that creates a block link (used to create a menu of links one per line)
+ */
+
+// Include NPM modules
+var React = require('react');
+
+var BlockLink = React.createClass({
+	displayName: 'BlockLink',
+	propTypes: {
+		url: React.PropTypes.string.isRequired,    // the anchor url
+		label: React.PropTypes.string.isRequired,  // the anchor text
+		cssClass: React.PropTypes.string           // the cssClass to bind onto the element
+	},
+	getDefaultProps: function() {
+		return {
+			cssClass: ''
+		};
+	},
+	render: function(){
+		return (<a href={this.props.url} className={this.props.cssClass}>{this.props.label}</a>);		
+	}
+});
+
+module.exports = BlockLink;

--- a/app/templates/templates/default-react/components/elements/CategoryBlockLinkList.jsx
+++ b/app/templates/templates/default-react/components/elements/CategoryBlockLinkList.jsx
@@ -1,0 +1,56 @@
+/*
+ *  @file: CategoryBlockLinkList takes the array of categories and creates a list of block item links 
+ *  which are displayed as category navigation on the blog[layout] on posts page.
+ */
+
+// Include NPM modules
+var React = require('react');
+var _ = require('underscore');
+var cx = require('classnames');
+
+var Mixins = require('../../mixins');
+var BlockLink = require('./BlockLink');
+
+var CategoryBlockLinkList = React.createClass({
+	displayName: 'CategoryBlockLinkList',
+	mixins: [Mixins],
+	propTypes: {
+		categories: React.PropTypes.array,                    // an array of {'key':'', label:''} for each category
+		selectedCategory: React.PropTypes.string.isRequired   // the selected categories `key`
+	},
+	getDefaultProps: function() {
+		return {
+			categories: []
+		};
+	},
+	createCategoryList: function() {
+		// Iterate over our categories and create a list of block item links
+		var list = _.map(this.props.categories, function(categoryItem, index) {
+			// if selected enable active css class
+			var itemAnchorClass = cx({
+				active: (this.props.selectedCategory === categoryItem.key),
+				'list-group-item': true
+			});
+			// create each link
+			return (<BlockLink key={categoryItem.key} url={this.getRouteUrl('category', categoryItem.key)} label={categoryItem.name} cssClass={itemAnchorClass} />);
+		}, this);
+		
+		// Create our AllCategory Menu Item and place at head (unshift) on the array
+		var allAnchorClass = cx({
+			active: (this.props.selectedCategory === 'AllCategories'),
+			'list-group-item': true
+		});
+		list.unshift(<BlockLink key={'AllCategory'} url={this.getRouteUrl('blog', '')} label={'All Categories'} cssClass={allAnchorClass} />)
+		return list;
+	},
+	render: function(){
+		var ListItems = this.createCategoryList();
+		return (
+			<div>
+				{ListItems}
+			</div>		
+		);		
+	}
+});
+
+module.exports = CategoryBlockLinkList;

--- a/app/templates/templates/default-react/components/elements/CategoryInlineLinkList.jsx
+++ b/app/templates/templates/default-react/components/elements/CategoryInlineLinkList.jsx
@@ -1,0 +1,62 @@
+/*
+ *  @file: CategoryLinkList takes the array of categories and creates an inline list display
+ *  if passed the `autoLink` to true it will link the categories to a blog post page filtering on just those categories
+ *  otherwise it will be just a static string of categories
+ */
+// Include NPM modules
+var React = require('react');
+var _ = require('underscore');
+
+// include our react libs
+var Mixins = require('../../mixins');
+var InlineLink = require('./InlineLink');
+
+var CategoryInlineLinkList = React.createClass({
+	displayName: 'CategoryInlineLinkList',
+	mixins: [Mixins],
+	propTypes: {
+		prefix: React.PropTypes.string,     // the prefix `Posted in` before appending the list of categories
+		suffix: React.PropTypes.string,     // an ending suffix opposite of prefix
+		categories: React.PropTypes.array,  // an array of {key:'', name:''} for each category
+		autoLink: React.PropTypes.bool,     // boolean which will generate an anchor for each category and wrap it
+		separator: React.PropTypes.string,  // what string is used to seprat
+		cssClass: React.PropTypes.string
+	},
+	getDefaultProps: function() {
+		return {
+			separator: ', ',
+			autoLink: false,
+			prefix: '',
+			suffix: '',
+			categories: []
+		};
+	},
+	createCategoryList: function() {
+		var categoryNames = _.pluck(this.props.categories, 'name');
+		if (this.props.autoLink) {
+			return _.map(this.props.categories, function(categoryItem, index) {
+				// check if our iteration is the last item
+				var isLastItem = ((this.props.categories.length-1) === index);
+				// includeSeparator wants to ensure it is not the last item 
+				return (<InlineLink key={categoryItem.key} url={this.getRouteUrl('category', categoryItem.key)} label={categoryItem.name} includeSeparator={!isLastItem} />);
+			}, this);
+		} else {
+			return _.escape(categoryNames.join(this.props.separator));
+		}
+	},
+	render: function(){
+		var ListItems = this.createCategoryList();
+		if (ListItems.length > 0) {
+			return (
+				<p className={this.props.cssClass}>
+					{this.props.prefix} {ListItems} {this.props.suffix}
+				</p>		
+			);		
+		// TODO find a better return for no categories
+		} else {
+			return (<p></p>);
+		}
+	}
+});
+
+module.exports = CategoryInlineLinkList;

--- a/app/templates/templates/default-react/components/elements/FlashMessage.jsx
+++ b/app/templates/templates/default-react/components/elements/FlashMessage.jsx
@@ -1,0 +1,48 @@
+/**
+ * @file React Component to handle the flash message
+ */
+var React = require('react');
+var _ = require('underscore');
+var cx = require('classnames');
+
+var FlashMessage  = React.createClass({
+	displayName: 'FlashMessage',
+	propTypes: {
+		typeKey: React.PropTypes.string,  // matches up the class name: could be `error`, `warning`, `success`, `info`
+		title: React.PropTypes.string,    // The message title from server validation
+		list: React.PropTypes.array,      // an array of strings for each validation message
+		detail: React.PropTypes.string    // if no list provided there could just be a blog of text instead
+	},
+	getMessageContent: function() {
+		// check if detail or list set
+		// if detail return a simple p tag
+		// if list return a <ul><li*></ul>
+		if(this.props.detail){
+			return (<p>{this.props.detail}</p>);
+		} else if (this.props.list) {
+			// map and return list items
+			var items = this.props.list.map(function(item, ctr){
+				return (<li key={ctr}>{item}</li>);
+			});
+			return (<ul>{items}</ul>);
+		}
+	},
+	render: function() {
+		var messageContent = this.getMessageContent();
+		var messageClassName = cx({
+			'alert': true,
+			'alert-danger': (this.props.typeKey === 'error'),
+			'alert-warning': (this.props.typeKey === 'warning'),
+			'alert-success': (this.props.typeKey === 'success'),
+			'alert-info': (this.props.typeKey === 'info')
+		});
+		return (
+			<div className={messageClassName}>
+				<h4>{this.props.title}</h4>
+				<p>{messageContent}</p>
+			</div>
+		);
+	}
+});
+
+module.exports = FlashMessage;

--- a/app/templates/templates/default-react/components/elements/FlashMessages.jsx
+++ b/app/templates/templates/default-react/components/elements/FlashMessages.jsx
@@ -1,0 +1,39 @@
+/**
+ * @file React Component to handle the flash messages passed from express/payload
+ */
+var React = require('react');
+var _ = require('underscore');
+var cx = require('classnames');
+
+var FlashMessage = require('./FlashMessage');
+
+var FlashMessages  = React.createClass({
+	displayName: 'FlashMessages',
+	propTypes: {
+		messages: React.PropTypes.object  // an object with keys that map for what type of validation/messages sent by server
+	},
+	getMessages: function() {
+		var messages = [];
+		// use underscore/lodash to iterator over a message obk with keys
+		_.each(this.props.messages, function(message, key) {
+			// only buffer the FlashMessage if it has data
+			if(message.length > 0) {
+				messages.push(<FlashMessage key={key} typeKey={key} {...message[0]} />);
+			}
+		});
+		// return the buffered FlashMessage Components
+		return messages;
+
+	},
+	render: function() {
+		// get our message buffer components
+		var messages = this.getMessages();
+		return (
+			<div id="flash-messages" className="container">
+				{messages}
+			</div>
+		);
+	}
+});
+
+module.exports = FlashMessages;

--- a/app/templates/templates/default-react/components/elements/InlineLink.jsx
+++ b/app/templates/templates/default-react/components/elements/InlineLink.jsx
@@ -1,0 +1,27 @@
+/**
+ *  @file:  a simple component element that is used to build an anchor but if passed params can be used to assemble
+ *  a concatenated string separated by `, `  default
+ */
+// Include NPM modules
+var React = require('react');
+
+var InlineLink = React.createClass({
+	displayName: 'InlineLink',
+	propTypes: {
+		url: React.PropTypes.string.isRequired,    // the anchor url
+		label: React.PropTypes.string.isRequired,  // the anchor label
+		includeSeparator: React.PropTypes.bool,    // specifies if we should include a string separator
+		separator: React.PropTypes.string          // override the default `, `
+	},
+	getDefaultProps: function() {
+		return {
+			includeSeparator: false,
+			separator: ', '
+		};
+	},
+	render: function(){
+		return (<span><a href={this.props.url}>{this.props.label}</a>{this.props.includeSeparator? ', ': ' '}</span>);		
+	}
+});
+
+module.exports = InlineLink;

--- a/app/templates/templates/default-react/components/elements/Jumbotron.jsx
+++ b/app/templates/templates/default-react/components/elements/Jumbotron.jsx
@@ -1,0 +1,39 @@
+/**
+ *  @file: a component that houses all the html to display the jumbotron html, little reason to decouple this out into
+ * 	additional component elements (could if we wanted)
+ *  *NOTE* this could be componentized more, but opted to keep it simple and just have the html contained inside of a single component
+ */
+
+// Include NPM modules
+var React = require('react');
+
+var Jumbotron = React.createClass({
+	displayName: 'Jumbotron',
+	render: function(){
+		var signinStyle = {marginRight: '10px'};
+		return (
+			<div className="container">
+				<div className="jumbotron"><img src="/images/logo.svg" width="160" />
+					<h1>Welcome</h1>
+					<p>This is your new <a href='http://keystonejs.com' target='_blank'>KeystoneJS</a> website.</p>
+					<p>
+						It includes the latest versions of
+						<a href='http://getbootstrap.com/' target='_blank'>Bootstrap</a>
+						and <a href='http://www.jquery.com/' target='_blank'>jQuery</a>.
+					</p>
+					<p>Visit the <a href='http://keystonejs.com/guide' target='_blank'>Getting Started</a> guide to learn how to customise it.</p>
+					<hr />
+					<p>We have created a default Admin user for you with the email <strong><%= adminLogin %></strong> and the password <strong><%= adminPassword %></strong>.</p>
+					<p><a href="/keystone/signin" style={signinStyle} className="btn btn-lg btn-primary">Sign in</a> to use the Admin UI.</p>
+					<hr />
+					<p>
+					Remember to <a href='https://github.com/keystonejs/keystone' target='_blank'>Star KeystoneJS on GitHub</a> and
+					<a href='https://twitter.com/keystonejs' target='_blank'>follow @keystonejs</a> on twitter for updates.
+					</p>
+				</div>
+			</div>
+		);		
+	}
+});
+
+module.exports = Jumbotron;

--- a/app/templates/templates/default-react/components/elements/NavItem.jsx
+++ b/app/templates/templates/default-react/components/elements/NavItem.jsx
@@ -1,0 +1,28 @@
+/**
+ *  @file: a single component navigation element (li + a)
+ *  
+ */
+var React = require('react');
+var cx = require('classnames');
+
+var NavItem = React.createClass({
+	displayName: 'NavItem',
+	propTypes: {
+		href: React.PropTypes.string.isRequired,   // anchor href 
+		label: React.PropTypes.string.isRequired,  // anchor label text
+		selected: React.PropTypes.bool             // is it selected if so include `active` class on element
+	},
+	render: function () {
+		// if selected enable active css class
+		var anchorClass = cx({
+			active: this.props.selected
+		});
+		return (
+			<li key={this.props.key} className={anchorClass}>
+				<a href={this.props.href}>{this.props.label}</a>
+			</li>
+		);
+	}
+});
+
+module.exports = NavItem;

--- a/app/templates/templates/default-react/components/elements/Pagination.jsx
+++ b/app/templates/templates/default-react/components/elements/Pagination.jsx
@@ -1,0 +1,74 @@
+/**
+ *  @file: the container component to handle creating a pagination (translates all props into pagination buttons)
+ *  
+ */
+// Include NPM modules
+var React = require('react');
+var cx = require('classnames');
+
+var Mixins = require('../../mixins');
+var PaginationButton = require('./PaginationButton');
+
+var Pagination = React.createClass({
+	displayName: 'Pagination',
+	mixins: [Mixins],
+	propTypes: {
+		totalPages: React.PropTypes.number,
+		// an array of integers? (might change if you hit a threshold for `...`)
+		pages: React.PropTypes.array,
+		// false if no next page, otherwise number
+		previousPage: React.PropTypes.node,
+		// false if no next page, otherwise number
+		nextPage: React.PropTypes.node,
+		// current page always a number
+		currentPage: React.PropTypes.number	
+	},
+	getPaginationButtons: function() {
+		return this.props.pages.map(function(page, ctr) {
+			var pageUrlSlug = page;
+			// keystone can return a '...' as part of the max pagination set (default 10), 
+			// in this case the jade template would link the `...` to which ever side so 1 or totalPages
+			// so ['...', 56, 57] would have '...' link to page 1
+			// in ['...', 57, 58, '...'] there would be a link to page 1 and total pages
+			if (page === '...') {
+				pageUrlSlug = ((ctr)? this.props.totalPages:1);
+			}
+			var pageClass = cx({
+				active: (page === this.props.currentPage)
+			});
+			return (<PaginationButton key={'paginationButton-' + pageUrlSlug} pageClass={pageClass} pageUrlSlug={pageUrlSlug} pageButtonLabel={page} />);	
+		}, this);
+	},
+	getPreviousButton: function() {
+		var page = ((this.props.previousPage === false)? 1 : this.props.previousPage); 
+		var pageClass = (this.props.previousPage === false)? 'disabled':'';
+		return (
+			<PaginationButton key={'paginationPrevButton'} pageClass={pageClass} 
+				pageUrlSlug={page} pageButtonGlyphIconClass={'glyphicon glyphicon-chevron-left'} />
+		);	
+	},
+	getNextButton: function() {
+		var page = ((this.props.nextPage === false)? 1 : this.props.nextPage); 
+		var pageClass = (this.props.nextPage === false)? 'disabled':'';
+		return (
+			<PaginationButton key={'paginationNextButton'} pageClass={pageClass} 
+				pageUrlSlug={page} pageButtonGlyphIconClass={'glyphicon glyphicon-chevron-right'} />
+		);	
+	},
+	render: function(){
+		var renderPreviousButton = this.getPreviousButton();
+		var renderNextButton = this.getNextButton();
+		var paginationButtons = this.getPaginationButtons();
+		return (
+			
+			<ul className="pagination">
+			    {renderPreviousButton} 
+				{paginationButtons}
+				{renderNextButton} 
+			</ul>
+			
+		);		
+	}
+});
+
+module.exports = Pagination;

--- a/app/templates/templates/default-react/components/elements/PaginationButton.jsx
+++ b/app/templates/templates/default-react/components/elements/PaginationButton.jsx
@@ -1,0 +1,53 @@
+/**
+ *
+ *  @file React PaginationButton acts as the low level (li + a) element factory for pagination
+ *  
+ */
+// Include NPM modules
+var React = require('react');
+
+var Mixins = require('../../mixins');
+
+var PaginationButton = React.createClass({
+	displayName: 'PaginationButton',
+	mixins: [Mixins],
+	propTypes: {
+		pageClass: React.PropTypes.string,                 // className to place on the anchor <li> (disable or other?)
+		pageUrlSlug: React.PropTypes.node,                 // the anchor url slug (passed into getPageUrl mixin to create app url)
+		pageButtonLabel: React.PropTypes.node,             // the anchor button label
+		pageButtonGlyphIconClass: React.PropTypes.string   // key to matchup the bootstrap glyph class (goes onto a <span>)
+
+	},
+	/*
+	 *  returns a react button/action that displays a node 
+	 *  button or will use a bootstrap glyph-icon 
+	 */
+	getActionRender: function() {
+		var actionRender = null;
+		// displays a button with text
+		if(this.props.pageButtonLabel){
+			actionRender = (
+				<li className={this.props.pageClass}>
+					<a href={this.getPageUrl('blog', this.props.pageUrlSlug)} >{this.props.pageButtonLabel}</a>
+				</li>);	
+		}
+		// Display a Span with a bootstrap icon class
+		if(this.props.pageButtonGlyphIconClass){
+			// pass `pageClass` as `disabled` to prevent usage using css-class
+			actionRender = (
+				<li className={this.props.pageClass}>
+					<a href={this.getPageUrl('blog', this.props.pageUrlSlug)}>
+						<span className={this.props.pageButtonGlyphIconClass}></span>
+					</a>
+				</li>
+			);
+		}
+		return actionRender;
+	},
+	render: function(){
+		var actionRender = this.getActionRender();
+		return actionRender;			
+	}
+});
+
+module.exports = PaginationButton;

--- a/app/templates/templates/default-react/components/elements/PostExcerpt.jsx
+++ b/app/templates/templates/default-react/components/elements/PostExcerpt.jsx
@@ -1,0 +1,35 @@
+/**
+ *  @file:  Component used to render a blog post excerpt which displays a readmore button
+ *  
+ */
+// Include NPM modules
+var React = require('react');
+
+// Include mixin
+var Mixins = require('../../mixins');
+var CategoryInlineLinkList = require('./CategoryInlineLinkList');
+
+var PostExcerpt = React.createClass({
+	displayName: 'PostExcerpt',
+	mixins: [Mixins],
+	propTypes: {
+		image: React.PropTypes.object,      // contains the blog posts image info/meta
+		title: React.PropTypes.string,      // title of the post
+		categories: React.PropTypes.array,  // an array of all the categories associated to post
+		content: React.PropTypes.object,    // the content object (text of blog post key/namespace as html/markdown)
+		author: React.PropTypes.object,     // the author name defined by the user associated to post
+		slug: React.PropTypes.string        // the url slug that will be handed off to our mixin.getRouteUrl
+	},
+	render: function(){
+		return (
+			<div className="post">
+				<h2><a href={this.getRouteUrl('post', this.props.slug)}>{this.props.title}</a></h2>
+				<CategoryInlineLinkList categories={this.props.categories} prefix={'Posted in '} autoLink={true} cssClass={'lead text-muted'} />
+				<p dangerouslySetInnerHTML={{__html: this.props.content.brief.html}}></p>
+				<p className="read-more"><a href={this.getRouteUrl('post', this.props.slug)}>Read more...</a></p>
+			</div>			
+		);		
+	}
+});
+
+module.exports = PostExcerpt;

--- a/app/templates/templates/default-react/components/elements/PostFull.jsx
+++ b/app/templates/templates/default-react/components/elements/PostFull.jsx
@@ -1,0 +1,44 @@
+/**
+ *  @file: a component that renders a single full post entry
+ *  
+ */
+// Include NPM modules
+var React = require('react');
+var AuthorByline = require('./AuthorByline');
+var CategoryInlineLinkList = require('./CategoryInlineLinkList');
+
+var PostFull = React.createClass({
+	displayName: 'PostFull',
+	propTypes: {
+		title: React.PropTypes.string,         // the title of the post
+		authorName: React.PropTypes.object,    // the authors name
+		categories: React.PropTypes.array,     // an array of categories associated to post
+		content: React.PropTypes.object        // the content object (text of blog post key/namespace as html/markdown)
+	},
+	render: function(){
+		return (
+			<div className="container">
+				<div className="row">
+					<div className="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
+						<article>
+							<p><a href="/blog">&larr; back to the blog</a></p>
+							<hr />
+							<header>
+								<h1>{this.props.title}</h1>
+								<h5>
+									<CategoryInlineLinkList categories={this.props.categories} prefix={'Posted in '} autoLink={true} cssClass={''} />
+									{(this.props.authorName.first)?
+									<AuthorByline name={this.props.authorName.first}/> :
+									''}
+								</h5>
+							</header>
+							<div className="post" dangerouslySetInnerHTML={{__html: this.props.content.extended.html}}></div>
+						</article>
+					</div>
+				</div>
+			</div>			
+		);		
+	}
+});
+
+module.exports = PostFull;

--- a/app/templates/templates/default-react/components/layouts/Layout.jsx
+++ b/app/templates/templates/default-react/components/layouts/Layout.jsx
@@ -1,0 +1,111 @@
+var React = require('react');
+
+var NavItem = require('../elements/NavItem');
+var FlashMessages = require('../elements/FlashMessages');
+
+var Layout = React.createClass({
+	displayName: 'Layout',
+	propTypes: {
+		pageTitle: React.PropTypes.string,
+		navLinks: React.PropTypes.array,
+		section: React.PropTypes.string,
+		enquirySubmitted: React.PropTypes.bool,
+		messages: React.PropTypes.any, // can be obj-literal, false, undefined
+		user: React.PropTypes.object
+	},
+	getDefaultProps: function() {
+		return {
+			pageTitle: 'My Site'
+		};
+	},
+	/*
+	 *  Provide an additional layer of logic around FlashMessage for
+	 *  if EnquirySubmitted is true then we create a success message json shape and pass it to <FlashMessage />
+	 *   **note** .props.messages is empty if form was submitted
+	 *  Otherwise, check if there are error messages in .props.message, if so render those
+	 *  if .props.message is false then there are no messages and if undefined means the page-route doesn't support message interface
+	 */
+	getFlashMessage: function() {
+		// our return stub
+		var messageSet = {};
+
+		// if enquirySubmitted then it was successful so build a flash message json-struct
+		if(this.props.enquirySubmitted) {
+			var messages = {
+				'success': [
+					{'title': 'Message Submitted', 'detail': 'Thank you for contacting'}
+				]
+			}
+			return messages;
+		// if there was no submission and this is a new page render or with errors
+		// construct our error message or return an empty message object (convert the false||undefined)
+		} else {
+			if(this.props.messages === false || typeof(this.props.messages) === 'undefined'){
+				return {};
+			} else {
+				return this.props.messages;
+			}
+		}
+	},
+	render: function () {
+		var navLinks = this.props.navLinks.map(function(item) {
+			var isSelected = (this.props.section === item.key);
+			return (<NavItem key={item.key} href={item.href} label={item.label} selected={isSelected} />);
+		}, this);
+		// instead of just handing off the props.message, do some logic/handling
+		var messages = this.getFlashMessage();
+		return (
+			<html>
+				<head>
+					<meta charSet="utf-8" />
+					<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+					<meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+					<title>{this.props.pageTitle}</title>
+					<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+					<link href="/styles/site.min.css" rel="stylesheet" />
+					
+				</head>
+				<body>
+					<div id="header">
+						<div className="container">
+							<div role="navigation" className="navbar navbar-default">
+								<div className="container-fluid">
+									<div className="navbar-header">
+										<button type="button" data-toggle="collapse" data-target=".navbar-collapse" className="navbar-toggle">
+											<span className="sr-only">Toggle navigation</span>
+											<span className="icon-bar"></span><span className="icon-bar"></span><span className="icon-bar"></span>
+										</button>
+										<a href="/" className="navbar-brand">AppleParrotPeach</a>
+									</div>
+									<div className="collapse navbar-collapse">
+										<ul className="nav navbar-nav navbar-left">
+											{navLinks}
+										</ul>
+										<ul className="nav navbar-nav navbar-right">
+											{(this.props.user)?
+											<li><a href="/keystone/signout">Sign Out</a></li>
+											:
+											<li><a href="/keystone/signin">Sign In</a></li>
+											}
+										</ul>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div id="body">
+					<FlashMessages messages={messages} />
+					{this.props.children}
+					</div>
+					<div className="container">
+						<div id="footer">
+							<p>Powered by <a href="http://keystonejs.com" target="_blank">KeystoneJS</a>.</p>
+						</div>
+					</div>
+				</body>
+			</html>
+		);
+	}
+});
+
+module.exports = Layout;

--- a/app/templates/templates/default-react/components/pages/ContactForm.jsx
+++ b/app/templates/templates/default-react/components/pages/ContactForm.jsx
@@ -1,0 +1,99 @@
+/**
+ * @file a React Component that represents a page for the keystone front-end application
+ */
+
+var React = require('react');
+var cx = require('classnames');
+
+var ContactForm = React.createClass({
+	displayName: 'ContactForm',
+	propTypes: {
+		validationErrors: React.PropTypes.object,   // an object that contains validation errors
+		formData: React.PropTypes.object,           // an object with all the form fields previously posted data
+		enquiryTypes: React.PropTypes.array         // an array with objects {value:'',label:''} to make select menu
+	},
+	getCSSClasses: function() {
+		var classes = {};
+		classes.name = cx({'form-group':true, 'has-error': ('name' in this.props.validationErrors)});
+		classes.email = cx({'form-group':true, 'has-error': ('email' in this.props.validationErrors)});
+		classes.message = cx({'form-group':true, 'has-error': ('message' in this.props.validationErrors)});
+		return classes;
+	},
+	enquiryTypeOptions: function() {
+		// stub in a basic empty option
+		this.props.enquiryTypes.unshift({value:'', label:'(select one)'});
+		var options = this.props.enquiryTypes.map(function(option, ctr) {
+			var isSelected = false;
+			if(this.props.formData.enquiryType === option.value){
+				isSelected = true;
+			}
+			return (<option key={ctr + '-' + option.value} value={option.value}>{option.label}</option>);
+		}, this);
+		return options;
+	},
+	render: function() {
+		// get the field classes (indicate if form validation error)
+		var fieldClasses = this.getCSSClasses();
+		// create a local variable so we can access property key easier in .jsx
+		var fullName = this.props.formData['name.full'];
+		var enquiryTypeOptions = this.enquiryTypeOptions();
+		// if form was already posted successfully, display a return link and hide form
+		if(this.props.enquirySubmitted){
+			return (
+				<div>
+					<div className="container">
+						<p>Return to <a href="/">home</a></p>
+					</div>
+				</div>
+			);
+		// else render contact form
+		} else {
+			return (
+				<div>
+					<div className="container">
+						<h1>Contact Us</h1>
+					</div>
+					<div className="container">
+						<div className="row">
+							<div className="col-sm-8 col-md-6">
+								<h3>Thanks for getting in touch.</h3>
+							
+								<form method="post">
+									<input type="hidden" name="action" value="contact" />
+									<div className={fieldClasses.name}>
+										<label>Name</label>
+										<input type="text" name="name.full"  className="form-control" defaultValue={fullName} />
+									</div>
+									<div className={fieldClasses.email}>
+										<label>Email</label>
+										<input type="email" name="email" className="form-control" defaultValue={this.props.formData.email} />
+									</div>
+									<div className="form-group">
+										<label>Phone</label>
+										<input type="text" name="phone" placeholder="(optional)" className="form-control" defaultValue={this.props.formData.phone} />
+									</div>
+									<div className="form-group">
+										<label>What are you contacting us about?</label>
+										<select name="enquiryType" className="form-control" defaultValue={this.props.formData.enquiryType}>
+											{enquiryTypeOptions}
+										</select>
+									</div>
+									<div className={fieldClasses.message}>
+										<label>Message</label>
+										<textarea name="message" placeholder="Leave us a message..." rows="4" className="form-control" defaultValue={this.props.formData.message} ></textarea>
+									</div>
+									<div className="form-actions">
+										<button type="submit" className="btn btn-primary">Send</button>
+									</div>
+								</form>
+					
+							</div>
+						</div>
+					</div>
+				</div>
+			);
+		}
+	}
+});
+
+module.exports = ContactForm;

--- a/app/templates/templates/default-react/components/pages/Gallery.jsx
+++ b/app/templates/templates/default-react/components/pages/Gallery.jsx
@@ -1,0 +1,22 @@
+/**
+ * @file a React Component that represents a page for the keystone front-end application
+ */
+var React = require('react');
+
+// Get Children Components
+// require them here
+
+var Gallery = React.createClass({
+	displayName: 'Gallery',
+	render: function() {
+		return (
+			<div>
+				<div className="container">
+					<h1>Gallery</h1>
+				</div>
+			</div>
+		);
+	}
+});
+
+module.exports = Gallery;

--- a/app/templates/templates/default-react/components/pages/Home.jsx
+++ b/app/templates/templates/default-react/components/pages/Home.jsx
@@ -1,0 +1,19 @@
+/**
+ * @file a React Component that represents a page for the keystone front-end application
+ */
+ 
+var React = require('react');
+
+// Get Children Components
+var Jumbotron = require('../elements/Jumbotron');
+
+var Home = React.createClass({
+	displayName: 'Home',
+	render: function() {
+		return (
+			<Jumbotron />
+		);
+	}
+});
+
+module.exports = Home;

--- a/app/templates/templates/default-react/components/pages/Posts.jsx
+++ b/app/templates/templates/default-react/components/pages/Posts.jsx
@@ -1,0 +1,61 @@
+/**
+ * @file a React Component that represents a page for the keystone front-end application
+ */
+var React = require('react');
+
+var PostExcerpt = require('../elements/PostExcerpt');
+var CategoryBlockLinkList = require('../elements/CategoryBlockLinkList');
+var Pagination = require('../elements/Pagination');
+
+var Posts = React.createClass({
+	displayName: 'Posts',
+	propTypes: {
+		posts: React.PropTypes.object,            // an object that contains `results` which is an array of posts and also several other values for pagination
+		categories: React.PropTypes.array,        // an array of categories
+		selectedCategory: React.PropTypes.string  // the selectedCategory if a filter/query was selected
+	},
+	getDefaultProps: function() {
+		return {
+			selectedCategory: 'AllCategories'
+		};
+	},
+	render: function () {
+		var listGroupStyle = {marginRight: '10px'};
+		var PostExcerptCollection = this.props.posts.results.map(function(post){
+			// using spread - http://facebook.github.io/react/docs/jsx-spread.html
+			return (<PostExcerpt key={post._doc.id} {...post._doc} />);
+		},this);
+		return (
+			<div>
+				<div className="container">
+					<h1>Blog</h1>
+				</div>
+				<div className="container">
+					<div className="row">
+						<div className="col-sm-8 col-md-9">
+							<h4 className="text-weight-normal">Showing {this.props.posts.total} post.</h4>
+							<div className="blog">
+								{/* iterator for blog posts */}
+								{PostExcerptCollection}
+							</div>
+						</div>
+						<div className="col-sm-4 col-md-3">
+							<h2>Categories</h2>
+							<div style={listGroupStyle} className="list-group">
+								{/* category iterator */}
+								<CategoryBlockLinkList categories={this.props.categories} selectedCategory={this.props.selectedCategory} />
+								{/* category iteration */}
+							</div>
+						</div>
+					</div>
+					{/* pagintation */}
+					<Pagination totalItems={this.props.posts.total} currentPage={this.props.posts.currentPage} pages={this.props.posts.pages} 
+						totalPages={this.props.posts.totalPages} previousPage={this.props.posts.previous} nextPage={this.props.posts.next}
+					/>
+				</div>
+			</div>
+		);
+	}
+});
+
+module.exports = Posts

--- a/app/templates/templates/default-react/components/views/blog.jsx
+++ b/app/templates/templates/default-react/components/views/blog.jsx
@@ -1,0 +1,31 @@
+/**
+ * @file This react component (blog) serves as the primary entry point for the react app when express hands off the template context.data
+ *  unfortunately the file name `blog.xxx` has to match what the server/route express calls thus the file name is not BlogViewContainer.jsx
+ */
+// Include NPM modules
+var React = require('react');
+
+// Include React Components
+var Layout = require('../layouts/Layout');
+var Posts = require('../pages/Posts');
+
+
+var BlogViewContainer = React.createClass({
+	displayName: 'BlogViewContainer',
+	propTypes: {
+		data: React.PropTypes.object,           // the template data context passed from express (contains the posts)
+		navLinks: React.PropTypes.array,        // an array of nav elements
+		section: React.PropTypes.string,        // the selected section
+		user: React.PropTypes.object            // an object that consists of the user name
+	},
+	render: function() {
+		return (
+			<Layout navLinks={this.props.navLinks} user={this.props.user} section={this.props.section}>
+				<Posts posts={this.props.data.posts} categories={this.props.data.categories} selectedCategory={this.props.filters.category} />	
+			</Layout>
+		);		
+	}
+
+});
+
+module.exports = BlogViewContainer;

--- a/app/templates/templates/default-react/components/views/contact.jsx
+++ b/app/templates/templates/default-react/components/views/contact.jsx
@@ -1,0 +1,42 @@
+/**
+ * @file This react component (contact) serves as the primary entry point for the react app when express hands off the template context.data
+ *  unfortunately the file name `contact.xxx` has to match what the server/route express calls thus the file name is not ContactViewContainer.jsx
+ */
+
+// Include NPM modules
+var React = require('react');
+
+// Include React Components
+var Layout = require('../layouts/Layout');
+var ContactForm = require('../pages/ContactForm');
+
+
+var ContactViewContainer = React.createClass({
+	displayName: 'ContactViewContainer',
+	propTypes: {
+		data: React.PropTypes.object,           // the template data context passed from express
+		navLinks: React.PropTypes.array,        // an array of nav elements
+		section: React.PropTypes.string,        // the selected section
+		user: React.PropTypes.object,           // an object that consists of the user name
+		/**
+		 * message can be `false` or an object-literal 
+		 */
+		messages: React.PropTypes.oneOfType([
+      		React.PropTypes.bool,
+      		React.PropTypes.object
+    	])
+	},
+	render: function() {
+		return (
+			<Layout navLinks={this.props.navLinks} user={this.props.user} section={this.props.section} 
+				messages={this.props.messages} enquirySubmitted={this.props.enquirySubmitted}>
+				<ContactForm validationErrors={this.props.validationErrors} 
+					formData={this.props.formData} 
+					enquiryTypes={this.props.enquiryTypes} enquirySubmitted={this.props.enquirySubmitted} />
+			</Layout>
+		);		
+	}
+
+});
+
+module.exports = ContactViewContainer;

--- a/app/templates/templates/default-react/components/views/gallery.jsx
+++ b/app/templates/templates/default-react/components/views/gallery.jsx
@@ -1,0 +1,31 @@
+/**
+ * @file This react component (gallery) serves as the primary entry point for the react app when express hands off the template context.data
+ *  unfortunately the file name `gallery.xxx` has to match what the server/route express calls thus the file name is not GalleryViewContainer.jsx
+ */
+// Include NPM modules
+var React = require('react');
+
+// Include React Components
+var Layout = require('../layouts/Layout');
+var Gallery = require('../pages/Gallery');
+
+
+var GalleryViewContainer = React.createClass({
+	displayName: 'GalleryViewContainer',
+	propTypes: {
+		data: React.PropTypes.object,           // the template data context passed from express
+		navLinks: React.PropTypes.array,        // an array of nav elements
+		section: React.PropTypes.string,        // the selected section
+		user: React.PropTypes.object           // an object that consists of the user name
+	},
+	render: function() {
+		return (
+			<Layout navLinks={this.props.navLinks} user={this.props.user} section={this.props.section}>
+				<Gallery />
+			</Layout>
+		);		
+	}
+
+});
+
+module.exports = GalleryViewContainer;

--- a/app/templates/templates/default-react/components/views/index.jsx
+++ b/app/templates/templates/default-react/components/views/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * @file This react component (home) serves as the primary entry point for the react app when express hands off the template context.data
+ *  unfortunately the file name `index.xxx` has to match what the server/route express calls thus the file name is not HomeViewContainer.jsx
+ */
+// Include NPM modules
+var React = require('react');
+
+// Include React Components
+var Layout = require('../layouts/Layout');
+var Home = require('../pages/home');
+
+
+var HomeViewContainer = React.createClass({
+	propTypes: {
+		navLinks: React.PropTypes.array,        // an array of nav elements
+		section: React.PropTypes.string,        // the selected section
+		user: React.PropTypes.object            // an object that consists of the user name
+	},
+	render: function(){
+		return (
+			<Layout navLinks={this.props.navLinks} user={this.props.user} section={this.props.section}>
+				<Home />	
+			</Layout>
+		);		
+	}
+
+});
+
+module.exports = HomeViewContainer;

--- a/app/templates/templates/default-react/components/views/post.jsx
+++ b/app/templates/templates/default-react/components/views/post.jsx
@@ -1,0 +1,34 @@
+/**
+ * @file This react component (post) serves as the primary entry point for the react app when express hands off the template context.data
+ *  unfortunately the file name `post.xxx` has to match what the server/route express calls thus the file name is not PostViewContainer.jsx
+ */
+// Include NPM modules
+var React = require('react');
+
+// Include React Components
+var Layout = require('../layouts/Layout');
+var PostFull = require('../elements/PostFull');
+
+
+var PostViewContainer = React.createClass({
+	displayName: 'Blog',
+	propTypes: {
+		data: React.PropTypes.object,           // the template data context passed from express (contains the post data)
+		navLinks: React.PropTypes.array,        // an array of nav elements
+		section: React.PropTypes.string,        // the selected section
+		user: React.PropTypes.object            // an object that consists of the user name
+	},
+	render: function(){
+		var post = this.props.data.post;
+		return (
+			<Layout navLinks={this.props.navLinks} user={this.props.user} section={this.props.section}>
+				{/* had issue with ...post as spread operator working */}
+				<PostFull authorName={post.author.name} title={post.title} content={post.content} categories={post.categories} />	
+				}
+			</Layout>
+		);		
+	}
+
+});
+
+module.exports = PostViewContainer;

--- a/app/templates/templates/default-react/constants/urls.js
+++ b/app/templates/templates/default-react/constants/urls.js
@@ -1,0 +1,7 @@
+var urls = {
+    'post': '/blog/post',
+    'blog': '/blog',
+    'category': '/blog'
+};
+
+module.exports = urls;

--- a/app/templates/templates/default-react/mixins/index.jsx
+++ b/app/templates/templates/default-react/mixins/index.jsx
@@ -1,0 +1,21 @@
+/*
+ * @file Global mixin file, if building a larger app one should create
+ *  mixins of similar functionality instead of a single global file.
+ */
+
+// define the application url structure as constants here 
+// that way if routes/urls change you edit them in one place
+var URLS = require('../constants/urls');
+
+var mixins = {
+	// used to generate stand content urls, excludes pagination
+	getRouteUrl: function(section, slug) {
+		return (URLS[section] + '/' + slug);
+	},
+	// used for pagination buttons for a content section
+	getPageUrl: function(section, page) {
+		return (URLS[section]+ '?page=' + page);
+	}
+};
+
+module.exports = mixins;


### PR DESCRIPTION
## Overview

Added the React Template port of the current Default KeystoneTemplate.  Currently the missing pieces would are the actual Email Message and the Gallery Views.  Also, the base layout could use the inline editing javascript added back into place.  Currently this includes the actual generator hooks to prompt user for the `react` template and to then generate components for the `home`, `blog`, `message` pages.
## Architecture

Everything has been built as pure render components and placed into the `components/elements` folder.  The `components/views` act as a proxy to the express handler transfer `props` to the actual base `components/pages` which then call the `layouts/Layout` base.
