### PR TITLE
Update node-sass dependency version

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -13,7 +13,7 @@
     "swig": "^1.4.1", <% } else if (viewEngine === 'nunjucks') { %>
     "consolidate": "^0.10.0",
     "nunjucks": "^1.0.5", <% } if (preprocessor === 'sass') { %>
-    "node-sass": "^2.1.1",
+    "node-sass": "^3.3.2",
     "node-sass-middleware": "^0.5.0", <% } %>
     "dotenv": "^1.1.0"
   },<% if (taskRunner === 'grunt') { %>


### PR DESCRIPTION
* fixes https://github.com/keystonejs/generator-keystone/issues/127
* node v4.0 introduced an incompatibility with older node-sass versions,
this change fixes generated keystone sites for users using recent node
versions