### PR TITLE
Fixed broken handling of Sass changes when Grunt is running

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -28,7 +28,8 @@
     "grunt-node-inspector": "^0.1.5",
     "time-grunt": "^0.3.1",
     "grunt-concurrent": "^0.5.0",
-    "grunt-nodemon": "^0.2.1",
+    "grunt-nodemon": "^0.2.1", <% if (preprocessor === 'sass') { %>
+    "grunt-sass": "^1.0.0", <% } %>
     "open": "0.0.5"
   },<% } else if (taskRunner === 'gulp') { %>
   "devDependencies": {


### PR DESCRIPTION
Added grunt-sass to devDependencies in package.json so changes to Sass files in dev are handled by Grunt.
Previously when a Sass file changed, Grunt would notice the change to the file but fail to run Sass, generating
this warning: "Warning: Task "sass" not found. Use --force to continue."

The problem was caused by the yeoman template not including grunt-sass in the devDependencies.

Issue [99](https://github.com/keystonejs/generator-keystone/issues/99) is related