### PR TITLE
Remove Yo PeerDependency - Fixes #139

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
   "devDependencies": {
     "mocha": "^2.3.3"
   },
-  "peerDependencies": {
-    "yo": ">=1.0.0"
-  },
   "engines": {
     "node": ">=0.10.0",
     "npm": ">=1.2.10"


### PR DESCRIPTION
Remove the Yo PeerDependency to prevent perpetual, often misleading "Unmet
PeerDependency" warnings when using NPM 3, resolves #139. The responsibility to install
Yo now rests on the end-user alone. "yo {generator name}" will already
succinctly inform the user should Yeoman be missing.

This solution has been deployed in [several](https://github.com/jolicode/generator-joli-symfony/issues/17) [other](https://github.com/yeoman/generator-gruntfile/commit/48338a0acb068b83ca81410a619c034171197fe7) [generators](https://github.com/Swiip/generator-gulp-angular/pull/873) already, including [generator-generator](https://github.com/yeoman/generator-generator/commit/14d39bc78a675742e5590b769a8d527fba81fa1f).