### PR TITLE
gulpfile watch:lint rewrite

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -27,10 +27,7 @@ gulp.task('lint', function(){
 
 // gulp watcher for lint
 gulp.task('watch:lint', function () {
-	gulp.src(paths.src)
-		.pipe(watch())
-		.pipe(jshint())
-		.pipe(jshint.reporter(jshintReporter));
+	gulp.watch(paths.src, ['lint']);
 });
 
 <% if (preprocessor === 'sass') { %>


### PR DESCRIPTION
Uses consistent coding style with watch:sass and fixed error I was getting preventing watch:lint/gulpfile from working.