### PR TITLE
fixed grunt lint to use .jshintrc file

### DIFF
--- a/app/templates/grunt/jshint.js
+++ b/app/templates/grunt/jshint.js
@@ -1,6 +1,7 @@
 module.exports = {
 	options: {
 		reporter: require('jshint-stylish'),
+		jshintrc: true,
 		force: true
 	},
 	all: [ 'routes/**/*.js',


### PR DESCRIPTION
Hi there,

I couldn't use grunt lint without this line in the linter's grunt file... Thought you would be happy to know

Thanks for the great work with this helpful generator for noobs like me