### PR TITLE
Filter the pagination for proper counts/page results

### DIFF
--- a/app/templates/routes/views/blog.js
+++ b/app/templates/routes/views/blog.js
@@ -63,9 +63,11 @@ exports = module.exports = function(req, res) {
 		var q = keystone.list('Post').paginate({
 				page: req.query.page || 1,
 				perPage: 10,
-				maxPages: 10
+				maxPages: 10,
+				filters: {
+					'state': 'published'
+				}
 			})
-			.where('state', 'published')
 			.sort('-publishedDate')
 			.populate('author categories');
 		


### PR DESCRIPTION
The current method causes bad page/count information to be returned in the result if you truly want posts that are published. Having a few hundred unpublished posts (drafts) will dramatically throw off the returned information and allow a bunch of page links leading to empty blog pages to be rendered in the default template.