### PR TITLE
Added Page entity type to model, as well as necessary template and route

### DIFF
--- a/app/templates/models/Page.js
+++ b/app/templates/models/Page.js
@@ -1,0 +1,30 @@
+var keystone = require('keystone');
+var slug = require('slug');
+
+var Types = keystone.Field.Types;
+
+/**
+ * Post Model
+ * ==========
+ */
+
+var Page = new keystone.List('Page', {
+	map: { name: 'title' },
+	autokey: { path: 'slug', from: 'title', unique: true }
+});
+
+Page.add({
+	title: { type: String, required: true },
+	url: { type: String, required: false},
+	content: {type: Types.Html, wysiwyg: true, height: 400 }
+});
+
+Page.schema.pre('save', function(next) {
+    if (!this.url) {
+        this.url = slug(this.title).toLowerCase();
+    }
+    next();
+});
+
+Page.defaultColumns = 'title';
+Page.register();

--- a/app/templates/routes/_index.js
+++ b/app/templates/routes/_index.js
@@ -38,6 +38,7 @@ exports = module.exports = function(app) {
 	app.get('/', routes.views.index);
 	<% if (includeBlog) { %>app.get('/blog/:category?', routes.views.blog);
 	app.get('/blog/post/:post', routes.views.post);
+	app.get('/:page', routes.views.page);
 	<% } %><% if (includeGallery) { %>app.get('/gallery', routes.views.gallery);
 	<% } %><% if (includeEnquiries) { %>app.all('/contact', routes.views.contact);<% } %>
 	<% if (includeGuideComments) { %>

--- a/app/templates/routes/views/page.js
+++ b/app/templates/routes/views/page.js
@@ -1,0 +1,36 @@
+var keystone = require('keystone');
+
+exports = module.exports = function(req, res) {
+
+	var view = new keystone.View(req, res);
+	var locals = res.locals;
+
+	// Set locals
+	locals.section = 'page';
+	locals.filters = {
+		page: req.params.page
+	};
+	locals.data = {
+		pages: []
+	};
+
+	// Load the current page
+	view.on('init', function(next) {
+
+		// try finding page by custom URL first
+		var q = keystone.list('Page').model.findOne({
+			url: locals.filters.page
+		});
+
+		q.exec(function(err, result) {
+			locals.data.page = result;
+			next(err);
+		});
+	});
+
+	console.log(locals.data.page);
+
+	// Render the view
+	view.render('page');
+
+};

--- a/app/templates/templates/default-swig/views/page.swig
+++ b/app/templates/templates/default-swig/views/page.swig
@@ -1,0 +1,23 @@
+{% extends "../layouts/default.swig" %}
+
+{% block content %}
+	<div class="container">
+		<div class="row">
+			<div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
+				<article>
+					<hr>
+					{% if not data.page %}
+						<h2>Invalid Page.</h2>
+					{% else %}
+						<header>
+							<h1>{{ data.page.title }}</h1>
+						</header>
+						<div class="post">
+							{{ data.page.content | raw }}
+						</div>
+					{% endif %}
+				</article>
+			</div>
+		</div>
+	</div>
+{% endblock %}


### PR DESCRIPTION
Posts don't quite fill the need that many site have for managing custom pages in the admin. The main missing feature is the ability to assign a custom URL of the form `www.mysite.com/my-custom-page` to a managed page, but there are also fields on posts - such as `author` - that don't really make sense for a regular page.

I've written the necessary model, route file, and swig template. The URL field gets automatically populated with the page's slug if none is filled in, so the page will always have an appropriate URL. I'm not as familiar with hbs, jade, and nunchucks so those templates will still need to be created.