### PR TITLE
Mandrill Copy Fix

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -193,7 +193,7 @@ KeystoneGenerator.prototype.prompts = function prompts() {
 					name: 'mandrillAPI',
 					message: '------------------------------------------------' +
 						'\n    Please enter your Mandrill API Key (optional).' +
-						'\n    See http://keystonejs.com/guide/config/#mandrill for more info.' +
+						'\n    See http://keystonejs.com/docs/configuration/#services-mandrill for more info.' +
 						'\n    ' +
 						'\n    You can skip this for now (we\'ll include a test key instead)' +
 						'\n    ' +


### PR DESCRIPTION
http://keystonejs.com/guide/config/#mandrill no longer leads to the correct page