### PR TITLE
Only show brief content in hbs blog template

### DIFF
--- a/app/templates/templates/default-hbs/views/blog.hbs
+++ b/app/templates/templates/default-hbs/views/blog.hbs
@@ -12,8 +12,8 @@
 					<p class="lead text-muted">{{{categoryList categories prefix="Posted in "}}}
 							{{#if author.name.first}}by {{author.name.first}}{{/if}}
 					</p>
-					<p>{{{content.extended}}}</p>
-					<p class="read-more"><a href="{{postUrl slug}}">Read more...</a></p>
+					<p>{{{content.brief}}}</p>
+					{{#if content.extended}}<p class="read-more"><a href="{{postUrl slug}}">Read more...</a></p>{{/if}}
 				</div>
 				{{/each}}
 			</div>


### PR DESCRIPTION
Suggested fix for #171 