### PR TITLE
replace tabs with spaces in stylus file & set email template engine for hbs

### DIFF
--- a/app/templates/_keystone.js
+++ b/app/templates/_keystone.js
@@ -94,7 +94,15 @@ keystone.set('email locals', {
 // Load your project's email test routes
 <% } %>
 keystone.set('email tests', require('./routes/emails'));
-<% } %><% if (includeGuideComments) { %>
+<% } %>
+<% if (viewEngine === 'hbs') { %>
+<% if (includeGuideComments) { %>
+// Switch Keystone Email defaults to handlebars
+<% } %>
+keystone.Email.defaults.templateExt = 'hbs';
+keystone.Email.defaults.templateEngine = require('handlebars');
+<% } %>
+<% if (includeGuideComments) { %>
 // Configure the navigation bar in Keystone's Admin UI
 <% } %>
 keystone.set('nav', {

--- a/app/templates/public/styles-stylus/site/_layout.styl
+++ b/app/templates/public/styles-stylus/site/_layout.styl
@@ -1,15 +1,15 @@
 #header
-	margin-top 30px
+    margin-top 30px
 
 
 #footer
-	margin-top 30px
-	border-top 1px solid gray-lighter
-	padding-top 30px
-	color gray-light
+    margin-top 30px
+    border-top 1px solid gray-lighter
+    padding-top 30px
+    color gray-light
 
 
 .gallery-image img
-	display block
-	max-width 100%
-	height auto
+    display block
+    max-width 100%
+    height auto


### PR DESCRIPTION
Fixes #140 and adds [hatzipani's snippet](https://github.com/keystonejs/keystone/issues/1441#issuecomment-151806743) to the keystone template to fix #98 for hbs emails