### PR TITLE
Fix 'cloudinary secure' with handlebars helper

### DIFF
--- a/app/templates/templates/default-hbs/views/helpers/index.js
+++ b/app/templates/templates/default-hbs/views/helpers/index.js
@@ -177,6 +177,7 @@ module.exports = function () {
 		context = context === null ? undefined : context;
 
 		if ((context) && (context.public_id)) {
+			options.hash.secure = keystone.get('cloudinary secure') || false;
 			var imageName = context.public_id.concat('.', context.format);
 			return cloudinary.url(imageName, options.hash);
 		}


### PR DESCRIPTION
Potential fix for #176 
cc @mxstbr 

I've tested this and it works, but I'm by no means saying it's the best fix. See what you think. 

The `|| false` is because in most cases `keystone.get('cloudinary secure')` will be undefined, as most people will not explicitly set it to false. 

I considered doing an if statement to only change `options.hash` if it was set, but this one liner seemed neater. 