### PR TITLE
Update Nunjucks template path to work with consolidate 0.14.1

### DIFF
--- a/app/templates/_keystone.js
+++ b/app/templates/_keystone.js
@@ -29,7 +29,7 @@ keystone.init({
 	'stylus': 'public',
 	<% } %>'static': 'public',
 	'favicon': 'public/favicon.ico',
-	'views': 'templates/views',<% if (viewEngine === 'nunjucks') { %>
+	'views': ['templates', 'templates/views'],<% if (viewEngine === 'nunjucks') { %>
 	'view engine': 'html',
 	'custom engine': cons.nunjucks,
 <% } else { %>

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -11,7 +11,7 @@
     "express-handlebars": "^3.0.0",
     "handlebars": "^4.0.5",<% } else if (viewEngine === 'swig') { %>
     "swig": "^1.4.1", <% } else if (viewEngine === 'nunjucks') { %>
-    "consolidate": "^0.10.0",
+    "consolidate": "^0.14.1",
     "nunjucks": "^1.0.5", <% } else if (viewEngine === 'twig') { %>
 	"twig":"^0.8.9",
 	<% } if (preprocessor === 'sass') { %>

--- a/app/templates/templates/default-nunjucks/layouts/default.html
+++ b/app/templates/templates/default-nunjucks/layouts/default.html
@@ -1,4 +1,4 @@
-{% import "templates/mixins/flash-messages.html" as FM %}
+{% import "mixins/flash-messages.html" as FM %}
 
 <!doctype html>
 <html>

--- a/app/templates/templates/default-nunjucks/views/blog.html
+++ b/app/templates/templates/default-nunjucks/views/blog.html
@@ -1,4 +1,4 @@
-{% extends "templates/layouts/default.html" %}
+{% extends "layouts/default.html" %}
 
 {% macro blogPost(post) %}
 <div class="post" data-ks-editable="editable(user, { list: " Post ", id: post.id })">

--- a/app/templates/templates/default-nunjucks/views/contact.html
+++ b/app/templates/templates/default-nunjucks/views/contact.html
@@ -1,4 +1,4 @@
-{% extends "templates/layouts/default.html" %}
+{% extends "layouts/default.html" %}
 
 {% block intro %}
 	<div class="container">

--- a/app/templates/templates/default-nunjucks/views/errors/404.html
+++ b/app/templates/templates/default-nunjucks/views/errors/404.html
@@ -1,4 +1,4 @@
-{% extends "templates/layouts/default.html" %}
+{% extends "layouts/default.html" %}
 
 {% block content %}
 	<div class="container">

--- a/app/templates/templates/default-nunjucks/views/errors/500.html
+++ b/app/templates/templates/default-nunjucks/views/errors/500.html
@@ -1,4 +1,4 @@
-{% extends "templates/layouts/default.html" %}
+{% extends "layouts/default.html" %}
 
 {% block content %}
 	<div class="container">

--- a/app/templates/templates/default-nunjucks/views/gallery.html
+++ b/app/templates/templates/default-nunjucks/views/gallery.html
@@ -1,4 +1,4 @@
-{% extends "templates/layouts/default.html" %}
+{% extends "layouts/default.html" %}
 
 {% block intro %}
 	<div class="container">

--- a/app/templates/templates/default-nunjucks/views/index.html
+++ b/app/templates/templates/default-nunjucks/views/index.html
@@ -1,4 +1,4 @@
-{% extends "templates/layouts/default.html" %}
+{% extends "layouts/default.html" %}
 
 {% block content %}
 	<div class="container">

--- a/app/templates/templates/default-nunjucks/views/post.html
+++ b/app/templates/templates/default-nunjucks/views/post.html
@@ -1,4 +1,4 @@
-{% extends "templates/layouts/default.html" %}
+{% extends "layouts/default.html" %}
 
 {% block content %}
 	<div class="container">


### PR DESCRIPTION
Fixes keystonejs/generator-keystone#181
A change was introduced in consolidate 0.14.1 that passes the express views setting to Nunjucks.
This resulted in the existing method of extends and import not working, this fix set a parent path for the views templates.