### PR TITLE
fix task runner none

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -122,6 +122,7 @@ KeystoneGenerator.prototype.prompts = function prompts () {
 			}, {
 				name: 'taskRunner',
 				message: 'Would you like to include gulp or grunt? ' + (('[gulp | grunt | none]').grey),
+                default: 'none',
 			}, {
 				type: 'confirm',
 				name: 'newDirectory',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -49,7 +49,7 @@
     "npm": ">=1.3.14"
   },
   "scripts": {
-    "start": "<%= (!!taskRunner) ? taskRunner : 'node keystone.js' %>"
+    "start": "<%= taskRunner !== 'none' ? taskRunner : 'node keystone.js' %>"
   },
   "main": "keystone.js"
 }


### PR DESCRIPTION
If you choose task runner 'none' then npm run script looks like 'none'