### PR TITLE
Resolve issue #203

### DIFF
--- a/app/templates/_keystone.js
+++ b/app/templates/_keystone.js
@@ -96,7 +96,7 @@ keystone.Email.defaults.templateEngine = require('handlebars');
 	<% if (includeBlog) { %>posts: ['posts', 'post-categories'],
 	<% } if (includeGallery) { %>galleries: 'galleries',
 	<% } if (includeEnquiries) { %>enquiries: 'enquiries',
-	<% } %><%= userModelPath %>: '<%= userModelPath %>',
+	<% } if (userModelPath.includes('-')) { %>'<%= userModelPath %>'<% } else { %><%= userModelPath %><% } %>: '<%= userModelPath %>',
 });
 <% if (includeGuideComments) { %>
 // Start Keystone to connect to your database and initialise the web server


### PR DESCRIPTION
Currently, multiword model names will create a model path in the nav
that is not a valid JS object key.

This adds quotes around the name if it was a multi-word model name in
the navigation panel.