### PR TITLE
Fix for "Posts has no field postCategory" error

### DIFF
--- a/app/templates/models/PostCategory.js
+++ b/app/templates/models/PostCategory.js
@@ -13,6 +13,6 @@ PostCategory.add({
 	name: { type: String, required: true },
 });
 
-PostCategory.relationship({ ref: 'Post', path: 'categories' });
+PostCategory.relationship({ ref: 'Post', path: 'posts', refPath: 'categories' });
 
 PostCategory.register();


### PR DESCRIPTION
It's related to https://github.com/keystonejs/keystone/issues/1870.