### PR TITLE
fixes #260 with valid property for gallery sort order

### DIFF
--- a/app/templates/routes/views/gallery.js
+++ b/app/templates/routes/views/gallery.js
@@ -9,7 +9,7 @@ exports = module.exports = function (req, res) {
 	locals.section = 'gallery';
 
 	// Load the galleries by sortOrder
-	view.query('galleries', keystone.list('Gallery').model.find().sort('sortOrder'));
+	view.query('galleries', keystone.list('Gallery').model.find().sort('-publishedDate'));
 
 	// Render the view
 	view.render('gallery');


### PR DESCRIPTION
This simple fix deals with the invalid-sort-order string in `gallery.js`