### PR TITLE
Fix .env saving #267

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -257,9 +257,9 @@ KeystoneGenerator.prototype.prompts = function prompts () {
 
 		this.prompt(prompts.config, function (props) {
 
-			_.each(props, function (val, key) {
+			_.each(props, _.bind(function (val, key) {
 				this[key] = val;
-			}, this);
+			}, this));
 
 			if (this.includeEmail && (this.mailgunAPI && this.mailgunDomain)) {
 				this.mailgunConfigured = true;


### PR DESCRIPTION
thisArg arguments for Lodash methods are no longer supported (see the v4 [changelog](https://github.com/lodash/lodash/wiki/Changelog#v400)).