### PR TITLE
Updated Node Sass to 4.9.1 for Cent OS 5 + and Node v7 +

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -13,7 +13,7 @@
     "nunjucks": "3.0.0", <% } else if (viewEngine === 'pug') { %>
     "pug": "2.0.0-beta11", <% } else if (viewEngine === 'twig') { %>
     "twig":"0.10.3",<% } if (preprocessor === 'sass') { %>
-    "node-sass": "4.5.0",
+    "node-sass": "4.9.1",
     "node-sass-middleware": "0.11.0", <% } else if (preprocessor === 'stylus') { %>
     "stylus": "0.54.5", <% } %>
     "dotenv": "4.0.0", <% if (includeEmail) { %>


### PR DESCRIPTION
For those using Sass this is to avoid the Unsupported Linux runtime error.

If you scroll to the bottom of the link you will see the supported environments https://github.com/sass/node-sass/releases/tag/v4.9.1